### PR TITLE
Change the Token field to the "Password" field

### DIFF
--- a/src/pages/LoginPage/index.js
+++ b/src/pages/LoginPage/index.js
@@ -253,6 +253,7 @@ export default function NewSessionPage() {
                                                 </div>
 
                                                 <input
+                                                    type="password"
                                                     id={"token"}
                                                     autoComplete="off"
                                                     placeholder="Token"


### PR DESCRIPTION
Change the Token field to the "Password" field to be hidden, so that the details can be saved in the browser.